### PR TITLE
Support ClimateEntityFeature.TURN_OFF + ClimateEntityFeature.TURN_ON

### DIFF
--- a/custom_components/ekon-local/climate.py
+++ b/custom_components/ekon-local/climate.py
@@ -29,7 +29,7 @@ REQUIREMENTS = [""]
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
 
 DEFAULT_NAME = "EKON Climate-Local"
 


### PR DESCRIPTION
Resolves https://github.com/hllhll/HomeAssistant-ekon-local/issues/31

Fixes warning logs from HA:
```
2024-08-24 22:33:47.301 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.ekon-local.climate.EkonLocalClimate'>) does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method. Please report it to the author of the 'ekon-local' custom integration
2024-08-24 22:33:47.301 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.ekon-local.climate.EkonLocalClimate'>) does not set ClimateEntityFeature.TURN_ON but implements the turn_on method. Please report it to the author of the 'ekon-local' custom integration
```
