### PR TITLE
Fix requirements syntax incompatible with Python 3.13

### DIFF
--- a/custom_components/ekon-local/manifest.json
+++ b/custom_components/ekon-local/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/hllhll/HomeAssistant-ekon-local",
   "dependencies": [],
   "codeowners": ["@hllhll"],
-  "requirements": ["git+https://github.com/hllhll/pyekonlib@master#pyekonlib==0.4.2"] 
+  "requirements": ["pyekonlib@git+https://github.com/hllhll/pyekonlib.git@0.4.2"] 
 }


### PR DESCRIPTION
This PR fixes an invalid pip requirement declaration in `manifest.json`. (issue #35 )

The integration previously combined a Git URL with a `==` version specifier, which is not supported by `pip`/`packaging` and causes Home Assistant to fail during setup—especially with Python 3.13.

#### What changed

* Updated the `pyekonlib` requirement to use a valid Git-based requirement format
* Ensures compatibility with current Home Assistant dependency handling

#### Why

* Prevents `InvalidRequirement` errors during integration setup
* Restores compatibility with Python 3.13 and newer `packaging` versions

No functional changes beyond dependency resolution.

#### Testing

Tested locally on Home Assistant 2026.1.0
Integration loads successfully and dependencies install without errors